### PR TITLE
Fix for root object

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -48,17 +48,20 @@ Meteor.publishWithRelations = (params) ->
 
 			key_map = mapping.foreign_key.split "."
 			if key_map.length > 1
-				if obj[key_map[0]] and _.isArray(obj[key_map[0]])
+				if obj[key_map[0]]
 					ids = []
 					_.each key_map, (k,i) ->
 						if i is 0 #if start
-							ids = _.pluck obj[k],key_map[i+1]
+							if _.isArray(obj[key_map[0]])
+								ids = _.pluck obj[k],key_map[i+1]
+							else if _.isObject(obj[key_map[0]])
+								ids = [obj[k][key_map[i+1]]]
 
 						else if i isnt key_map.length-1 #if not last
 							ids = _.flatten ids
 							ids = _.pluck ids,key_map[i+1]
 
-					mapFilter[mapping.key] = 
+					mapFilter[mapping.key] =
 						$in:ids
 				else
 					mapFilter = null


### PR DESCRIPTION
As discussed in this issue:
https://github.com/Lepozepo/meteor-publish-with-relations/issues/10
the use of objects were working.
`mappings: [ { foreign_key: "aList.obj1.obj2.obj3.AnotherList.obj4.Reference", collection: SubThings } ] })`
Only, it works unless tje object is the first element (root). Otherwise said, this would not work: 
`mappings: [ { foreign_key: "anObject.aList", collection: SubThings } ] })`
because the first part is an Object and not a List.
This pull request fix this.
